### PR TITLE
fix(login): change redirect to render for view alert messages

### DIFF
--- a/pkg/services/webui/handler/auth/login.go
+++ b/pkg/services/webui/handler/auth/login.go
@@ -20,20 +20,20 @@ func (h authHandler) login(c *fiber.Ctx) error {
 		if errFind != nil {
 			logger.Logger.Error().Err(errFind.Error).Str("event", "webui.login.find_user").Msg("failed to find user")
 			d["Error"] = "Failed to login"
-			return c.Redirect("/auth/login")
+			return c.Render("templates/login", d)
 		}
 
 		if user.Username == "" {
 			logger.Logger.Error().Err(fmt.Errorf("user not found")).Str("event", "webui.login.user_exist").Msg("user not exist: " + c.FormValue("username"))
 			d["Error"] = "User not exist"
-			return c.Redirect("/auth/login")
+			return c.Render("templates/login", d)
 		}
 
 		err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(c.FormValue("password")))
 		if err != nil {
 			logger.Logger.Error().Err(err).Str("event", "webui.login.compare_password").Msg("incorrect password for " + user.Username)
 			d["Error"] = "Incorrect password"
-			return c.Redirect("/auth/login")
+			return c.Render("templates/login", d)
 		}
 
 		store, _ := h.sessions.Get(c)
@@ -44,7 +44,7 @@ func (h authHandler) login(c *fiber.Ctx) error {
 		if errStore != nil {
 			logger.Logger.Error().Err(errStore).Str("event", "webui.login").Msg("failed to save session")
 			d["Error"] = "Internal server error"
-			return c.Redirect("/auth/login")
+			return c.Render("templates/login", d)
 		}
 
 		return c.Redirect("/")


### PR DESCRIPTION
no showing error messages in login page because when the app have an error, it's redirect to login page instead render the page.